### PR TITLE
refactor: capitalized component name

### DIFF
--- a/app/me/page.tsx
+++ b/app/me/page.tsx
@@ -3,7 +3,7 @@ import AuthContext from '@/contexts/AuthContext';
 import useAxios from '@/helpers/useAxios';
 import { useContext, useEffect, useState } from 'react';
 
-const page = () => {
+const Page = () => {
   const api = useAxios();
   const { logoutUser } = useContext(AuthContext);
   const [user, setUser] = useState('');
@@ -23,4 +23,4 @@ const page = () => {
   );
 };
 
-export default page;
+export default Page;


### PR DESCRIPTION
The component was previously named `page`, which is a generic term and not descriptive of its purpose. This commit renames the component to `Page` to improve readability and clarity.