### PR TITLE
Develop

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_HOST = http://127.0.0.1:8000

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_API_HOST = https://change-backend-da6ac1cd1856.herokuapp.com/

--- a/app/api/auth/callback/google/page.tsx
+++ b/app/api/auth/callback/google/page.tsx
@@ -9,7 +9,7 @@ const Page = () => {
   const searchParams = useSearchParams();
   useEffect(() => {
     const fetch_tokens = async (auth_code: any) => {
-      const response = await fetch('http://127.0.0.1:8000/api/auth/google/login', {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_API_HOST}/api/auth/google/login`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/helpers/useAxios.tsx
+++ b/helpers/useAxios.tsx
@@ -2,7 +2,7 @@ import AuthContext from '@/contexts/AuthContext';
 import axios from 'axios';
 import { useContext } from 'react';
 
-const baseURL = 'http://localhost:8000';
+const baseURL = process.env.NEXT_PUBLIC_API_HOST;
 
 const useAxios = () => {
   const { authTokens } = useContext(AuthContext);


### PR DESCRIPTION
Update the code to use the `NEXT_PUBLIC_API_HOST` environment variable instead of a hardcoded URL for the login endpoint. This ensures the application can connect to the correct API server regardless of the deployment environment.